### PR TITLE
fix: in-iframe active selection styling

### DIFF
--- a/core/assets/css/content.css
+++ b/core/assets/css/content.css
@@ -1108,7 +1108,7 @@ body.admin-color-sunrise {
 /**
  * Explicit active selection styling
  * 
- * @author Kevin Shenk
+ * @author Kevin Shenk (batonac)
  * @since 1.4.7
  */
 ::selection {


### PR DESCRIPTION
fixes #1 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix selection visibility in editor/iframe contexts**
> 
> - Adds global `::selection` styling with `background-color: var(--wp-admin-theme-color)` and white text to align active text selection with admin color schemes
> - Ensures consistent, visible selection states within the block editor iframe and across admin color themes in `core/assets/css/content.css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4de998b50ce2e7bf8d9dd1564e1760b40c6c7e90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->